### PR TITLE
Add line to split up buildkite log output (doesn't show requirements import by default)

### DIFF
--- a/{{cookiecutter.project_slug}}/scripts/unit_tests.sh
+++ b/{{cookiecutter.project_slug}}/scripts/unit_tests.sh
@@ -8,4 +8,6 @@ export LANG=en_AU.utf8
 cp pip.conf /etc/pip.conf
 
 /opt/python/cp37-cp37m/bin/pip install -r requirements.txt
+
+echo -e "--- Running \033[33mspecs\033[0m :pray:"
 /opt/python/cp37-cp37m/bin/pytest -n=${N_WORKERS} -v


### PR DESCRIPTION
Adding an echoed line that begins with `---` splits up the buildkite log, which in this case means we see the tests by default, without the requirements import, although it can still be viewed if wanted.